### PR TITLE
Update CoreNLP-related command line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,8 @@ setup:
 
 run-server:
 	cd data/corenlp && \
-	java -mx4g -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -preload tokenize,ssplit,pos,lemma,ner,parse,depparse -status_port 9000 -port 9000 -timeout 15000
+	java -mx4g -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -preload tokenize,ssplit,pos,lemma,ner,parse,depparse -status_port 9000 -port 9000 -timeout 30000
+
+run-low-server:
+	cd data/corenlp && \
+	java -mx1g -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -preload tokenize,ssplit,pos,lemma,ner,parse,depparse -status_port 9000 -port 9000 -timeout 30000

--- a/core/tree.py
+++ b/core/tree.py
@@ -21,10 +21,14 @@ class TreeParser:
                settings.CORENLP_MODEL_PATH,
             )
 
+            print("[TreeParser] Running CoreNLP Server...")
             server.start()
 
             self.server = server
             url = server.url
+
+        else:
+            print("[TreeParser] Using existing CoreNLP Server...")
 
         self.parser = CoreNLPParser(url=url)
 

--- a/main.py
+++ b/main.py
@@ -62,11 +62,15 @@ def main():
         }
 
     parser = argparse.ArgumentParser(description = 'Grade essay')
+    parser.add_argument('--corenlp-url', dest = 'corenlp_url', required = False, default = None)
     parser.add_argument('coverage', choices = ('all', 'sample'))
     parser.add_argument('targets', nargs='*')
 
     args = parser.parse_args()
     functions = []
+
+    if args.corenlp_url:
+        settings.CORENLP_URL = args.corenlp_url
 
     for target in args.targets:
         if target not in all_functions:


### PR DESCRIPTION
* Add `make run-low-server`, in favor of low-memory environment
* Add `--corenlp-url` in `main.py`, which changes `settings.CORENLP_URL`
	* Example: `python main.py sample plagiarism --corenlp-url "http://localhost:9000"`\
* The server became more tolerant, changed timeout from 15s to 30s